### PR TITLE
add hash modification possibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,19 @@ You can use this Facade anywhere in your application
 
 	/*
     |--------------------------------------------------------------------------
+    | Hash modification
+    |--------------------------------------------------------------------------
+    |
+    | You can disable usage of modification time (mtime) for hash build and
+	| add additional salt (exp. commit hash) for hash build
+    |
+    */
+
+    'disable_mtime' => false,
+    'hash_salt' => '',
+
+    /*
+    |--------------------------------------------------------------------------
     | Base URL
     |--------------------------------------------------------------------------
     |

--- a/src/Minify.php
+++ b/src/Minify.php
@@ -67,7 +67,7 @@ class Minify
    * @return string
    */
   public function javascript($file, $attributes = array()) {
-    $this->provider = new JavaScript(public_path());
+    $this->provider = new JavaScript(public_path(), ['hash_salt' => $this->config['hash_salt'], 'disable_mtime' => $this->config['disable_mtime']]);
     $this->buildPath = $this->config['js_build_path'];
     $this->attributes = $attributes;
     $this->buildExtension = 'js';
@@ -83,7 +83,7 @@ class Minify
    * @return string
    */
   public function stylesheet($file, $attributes = array()) {
-    $this->provider = new StyleSheet(public_path());
+    $this->provider = new StyleSheet(public_path(), ['hash_salt' => $this->config['hash_salt'], 'disable_mtime' => $this->config['disable_mtime']]);
     $this->buildPath = $this->config['css_build_path'];
     $this->attributes = $attributes;
     $this->buildExtension = 'css';
@@ -99,7 +99,7 @@ class Minify
    * @return string
    */
   public function stylesheetDir($dir, $attributes = array()) {
-    $this->provider = new StyleSheet(public_path());
+    $this->provider = new StyleSheet(public_path(), ['hash_salt' => $this->config['hash_salt'], 'disable_mtime' => $this->config['disable_mtime']]);
     $this->buildPath = $this->config['css_build_path'];
     $this->attributes = $attributes;
     $this->buildExtension = 'css';
@@ -113,7 +113,7 @@ class Minify
    * @return string
    */
   public function javascriptDir($dir, $attributes = array()) {
-    $this->provider = new JavaScript(public_path());
+    $this->provider = new JavaScript(public_path(), ['hash_salt' => $this->config['hash_salt'], 'disable_mtime' => $this->config['disable_mtime']]);
     $this->buildPath = $this->config['js_build_path'];
     $this->attributes = $attributes;
     $this->buildExtension = 'js';

--- a/src/MinifyServiceProvider.php
+++ b/src/MinifyServiceProvider.php
@@ -50,6 +50,8 @@ class MinifyServiceProvider extends ServiceProvider {
           'ignore_environments' => config('minify.config.ignore_environments'),
           'base_url' => config('minify.config.base_url'),
           'reverse_sort' => config('minify.config.reverse_sort'),
+          'disable_mtime' => config('minify.config.disable_mtime'),
+          'hash_salt' => config('minify.config.hash_salt'),
         ),
         $app->environment()
       );

--- a/src/Providers/BaseProvider.php
+++ b/src/Providers/BaseProvider.php
@@ -40,11 +40,24 @@ abstract class BaseProvider implements Countable
     private $publicPath;
 
     /**
+     * @var boolean
+     */
+	private $disable_mtime;
+
+    /**
+     * @var string
+     */
+	private $hash_salt;
+
+    /**
      * @param null $publicPath
      */
-    public function __construct($publicPath = null)
+    public function __construct($publicPath = null, $config = null)
     {
         $this->publicPath = $publicPath ?: $_SERVER['DOCUMENT_ROOT'];
+
+        $this->disable_mtime = $config['disable_mtime'] ?: false;
+        $this->hash_salt = $config['hash_salt'] ?: '';
 
         $value = function($key)
         {
@@ -209,7 +222,7 @@ abstract class BaseProvider implements Countable
      */
     protected function buildMinifiedFilename()
     {
-        $this->filename = $this->getHashedFilename() . $this->countModificationTime() . static::EXTENSION;
+        $this->filename = $this->getHashedFilename() . (($this->disable_mtime) ? '' : $this->countModificationTime()) . static::EXTENSION;
     }
 
     /**
@@ -258,7 +271,7 @@ abstract class BaseProvider implements Countable
      */
     protected function getHashedFilename()
     {
-        return md5(implode('-', $this->files));
+        return md5(implode('-', $this->files) . $this->hash_salt);
     }
 
     /**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -60,6 +60,19 @@ return array(
 
 	/*
     |--------------------------------------------------------------------------
+    | Hash modification
+    |--------------------------------------------------------------------------
+    |
+    | You can disable usage of modification time (mtime) for hash build and
+	| add additional salt (exp. commit hash) for hash build
+    |
+    */
+
+    'disable_mtime' => false,
+    'hash_salt' => '', 
+
+	/*
+    |--------------------------------------------------------------------------
     | Base URL
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
Hi sirsquall,

I add the possibility to modificate the filename hash. "disable_mtime" disables the usage of file modifiactiontime and "hash_salt" adds an additional string to md5 filename hash. In my case I use the commit key from environment variables.

Thanks for merge. If there is a problem, please let me know.

Regards,
Tobi
