### PR TITLE
crop puplicPath from filenames in hash build

### DIFF
--- a/src/Providers/BaseProvider.php
+++ b/src/Providers/BaseProvider.php
@@ -271,7 +271,8 @@ abstract class BaseProvider implements Countable
      */
     protected function getHashedFilename()
     {
-        return md5(implode('-', $this->files) . $this->hash_salt);
+        $publicPath = $this->publicPath;
+        return md5(implode('-', array_map(function($file) use ($publicPath) { return str_replace($publicPath, '', $file); }, $this->files)) . $this->hash_salt);
     }
 
     /**


### PR DESCRIPTION
Hi Alcindo,

thanks for the fast merge and the test correction. Sorry that I send this request directly. I saw that disallow of timestamp usage not work directly on AWS OpsWorks because the publicPath ist used in md5 hash build. On OpsWorks it contains the timestamp of deployment (exp. .../releases/20150818120738/...) so different on several servers. I cropped the publicPath now, that only the add()-given assets path is used for md5 (exp. /assets/css/bootstrap.min.css). Not the beautiful way, but the filesystem path in $this->files array is needed several times and for version control it themes to be enough.

Thanks,
Tobi
