### PR TITLE
Fix a wrong CannotSaveFileException

### DIFF
--- a/src/Providers/BaseProvider.php
+++ b/src/Providers/BaseProvider.php
@@ -334,7 +334,7 @@ abstract class BaseProvider implements Countable
      */
     protected function put($minified)
     {
-        if(!file_put_contents($this->outputDir . $this->filename, $minified))
+        if(file_put_contents($this->outputDir . $this->filename, $minified) === false)
         {
             throw new CannotSaveFileException("File '{$this->outputDir}{$this->filename}' cannot be saved");
         }


### PR DESCRIPTION
`file_put_contents` returns the number of bytes written or FALSE in case of failure.

Sometime there are some minified files that would be zero in size, generating a wrong CannotSaveFileException regardless the proper file creation.

This fix add a check for a boolean false fixing the wrong CannotSaveFileException on empty files (that would return "0")
